### PR TITLE
Update CMakeLists to build headers first

### DIFF
--- a/micvision/CMakeLists.txt
+++ b/micvision/CMakeLists.txt
@@ -162,15 +162,15 @@ add_executable(${PROJECT_NAME}_exploration_client
 ## add_executable(localization_client src/localization_client.cpp)
 add_executable(${PROJECT_NAME}_patroller src/patroller.cpp)
 
-add_dependencies(${PROJECT_NAME}_localization
+add_dependencies(${PROJECT_NAME}_localization ${${PROJECT_NAME}_EXPORTED_TARGETS}
     ${catkin_EXPORTED_TARGETS})
-add_dependencies(${PROJECT_NAME}_localization_node
+add_dependencies(${PROJECT_NAME}_localization_node ${${PROJECT_NAME}_EXPORTED_TARGETS}
     ${catkin_EXPORTED_TARGETS})
-add_dependencies(${PROJECT_NAME}_exploration
+add_dependencies(${PROJECT_NAME}_exploration ${${PROJECT_NAME}_EXPORTED_TARGETS}
     ${catkin_EXPORTED_TARGETS})
-add_dependencies(${PROJECT_NAME}_exploration_node
+add_dependencies(${PROJECT_NAME}_exploration_node ${${PROJECT_NAME}_EXPORTED_TARGETS}
     ${catkin_EXPORTED_TARGETS})
-add_dependencies(${PROJECT_NAME}_exploration_client
+add_dependencies(${PROJECT_NAME}_exploration_client ${${PROJECT_NAME}_EXPORTED_TARGETS}
     ${catkin_EXPORTED_TARGETS})
 ## add_dependencies(localization_client ${catkin_EXPORTED_TARGETS})
 

--- a/micvision/src/localization.cpp
+++ b/micvision/src/localization.cpp
@@ -248,7 +248,7 @@ void MicvisionLocalization::scoreLaserScanSamples() {
           }
 
           score = sample_score;
-          best_angle_ = -M_PI + i * laserscan_anglar_step_ * RADIAN_PRE_DEGREE;
+          best_angle_ = i * laserscan_anglar_step_ * RADIAN_PRE_DEGREE;
           best_position_ = Pixel(u, v);
         }
       }


### PR DESCRIPTION
Currently, message headers won't always get built first causing catkin make to fail on a fresh build. 
Ref: https://answers.ros.org/question/188982/message-headers-wont-build-first/

Also solves the reported issue: https://github.com/tyuownu/micvision/issues/10